### PR TITLE
Support environment injected configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project is out of date with https://github.com/Livefyre/py-yacc. Users
 should instead switch injected configs.
 
 ```
-export PYYACC_INJECT=$(pyyacc3 config/app.yaml /etc/default/cluster.yaml -o -)
+export YACC_INJECT=$(pyyacc3 config/app.yaml /etc/default/cluster.yaml -o -)
 ... run my program ...
 
 var config = yamljs.loadInjected();

--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
-yamljs
-====
+# yamljs
+
+## Notice
+This project is out of date with https://github.com/Livefyre/py-yacc. Users
+should instead switch injected configs.
+
+```
+export PYYACC_INJECT=$(pyyacc3 config/app.yaml /etc/default/cluster.yaml -o -)
+... run my program ...
+
+var config = yamljs.loadInjected();
+```
+
+# Overview
 
 Extends [js-yaml][1] with a few Livefyre specific types.
 
-To compile yaml to json
+# Usage
+To compile yaml to json:
 
 ```
 yamljs.js sample1.yaml sample2.yaml > config.json
 ```
 
-yamljs will take any number of yaml files and overlay them. For example, given two files: 
+yamljs will take any number of yaml files and overlay them. For example, given two files:
 
 **sample1.yaml**
 `env: dev`

--- a/index.js
+++ b/index.js
@@ -23,21 +23,21 @@ module.exports = exports = mergeYaml;
 
 exports.loadInjected = function (onErr) {
   try {
-    return exports.parse(process.env.PYYACC_INJECT);
+    return exports.parse(process.env.YACC_INJECT);
   } catch (e) {
     if (onErr) {
       return onErr(e);
     }
-    console.error('Unable to read PYYACC_INJECT environment variable', e);
+    console.error('Unable to read YACC_INJECT environment variable', e);
     process.exit(2);
   }
 }
 /**
- * Uses a fully hydrated config from `process.env.PYYACC_INJECT`,
+ * Uses a fully hydrated config from `process.env.YACC_INJECT`,
  * or falls back to the callback.
  */
 exports.loadInjectedOr = function (callback) {
-  if (!process.env.PYYACC_INJECT) {
+  if (!process.env.YACC_INJECT) {
     return callback();
   }
   return exports.loadInjected();

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ function mergeYaml(fileList) {
 
 module.exports = exports = mergeYaml;
 
+exports.mergeYaml = mergeYaml;
+
 exports.loadInjected = function (onErr) {
   try {
     return exports.parse(process.env.YACC_INJECT);

--- a/index.js
+++ b/index.js
@@ -21,6 +21,28 @@ function mergeYaml(fileList) {
 
 module.exports = exports = mergeYaml;
 
+exports.loadInjected = function (onErr) {
+  try {
+    return exports.parse(process.env.PYYACC_INJECT);
+  } catch (e) {
+    if (onErr) {
+      return onErr(e);
+    }
+    console.error('Unable to read PYYACC_INJECT environment variable', e);
+    process.exit(2);
+  }
+}
+/**
+ * Uses a fully hydrated config from `process.env.PYYACC_INJECT`,
+ * or falls back to the callback.
+ */
+exports.loadInjectedOr = function (callback) {
+  if (!process.env.PYYACC_INJECT) {
+    return callback();
+  }
+  return exports.loadInjected();
+}
+
 exports.stringify = function (obj, options) {
   return yaml.safeDump(obj, {schema: schema});
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "ross@livefyre.com"
   },
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "dependencies": {
     "js-yaml": "2.1.3",

--- a/yamljs.js
+++ b/yamljs.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
-var mergeYaml = require('./index');
+var parser = require('./index');
 
 var args = process.argv.slice(2);
 
-var obj = mergeYaml(args);
+var obj = parser.loadInjectedOr(function () {
+  return parser.mergeYaml(args);
+});
+
 console.log(JSON.stringify(obj));


### PR DESCRIPTION
Our requirements for config management have become more complex, and it makes sense to externalize configuration composition, and instead inject it via the environment.

This presents a simple mechanism for pulling an entire (prevalidated) config from an environment variable.